### PR TITLE
Specify coordinates without square brackets

### DIFF
--- a/src/test/java/shouty/ShoutSteps.java
+++ b/src/test/java/shouty/ShoutSteps.java
@@ -13,12 +13,12 @@ public class ShoutSteps {
     private static final String ARBITRARY_MESSAGE = "Hello, world";
     private final Shouty shouty = new Shouty();
 
-    @Given("^Lucy is at \\[(\\d+), (\\d+)\\]$")
+    @Given("^Lucy is at (\\d+), (\\d+)$")
     public void lucy_is_at(int xCoord, int yCoord) throws Throwable {
         shouty.setLocation("Lucy", new Coordinate(xCoord, yCoord));
     }
 
-    @Given("^Sean is at \\[(\\d+), (\\d+)\\]$")
+    @Given("^Sean is at (\\d+), (\\d+)$")
     public void sean_is_at(int xCoord, int yCoord) throws Throwable {
         shouty.setLocation("Sean", new Coordinate(xCoord, yCoord));
     }

--- a/src/test/resources/shouty/hear_shout.feature
+++ b/src/test/resources/shouty/hear_shout.feature
@@ -4,13 +4,13 @@ Feature: Hear Shout
 
 
   Scenario: In range shout is heard
-    Given Lucy is at [0, 0]
-    And Sean is at [0, 900]
+    Given Lucy is at 0, 0
+    And Sean is at 0, 900
     When Sean shouts
     Then Lucy should hear Sean
 
   Scenario: Out of range shout is not heard
-    Given Lucy is at [0, 0]
-    And Sean is at [0, 1100]
+    Given Lucy is at 0, 0
+    And Sean is at 0, 1100
     When Sean shouts
     Then Lucy should hear nothing


### PR DESCRIPTION
The workbook doesn't specify coordinates using square brackets. The example we want participants to start from shouldn't do it either.