### PR TITLE
Upgrade to Cucumber-JVM 6.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,11 @@ repositories {
 }
 
 dependencies {
-  compile group: 'org.springframework', name: 'spring-context', version:'4.3.10.RELEASE'
-  testCompile group: 'io.cucumber', name: 'cucumber-spring', version:'2.1.0'
-  testCompile group: 'io.cucumber', name: 'cucumber-junit', version:'2.1.0'
-  testCompile group: 'io.cucumber', name: 'pro-plugin', version:'1.2.9'
-  testCompile group: 'org.springframework', name: 'spring-test', version:'4.3.10.RELEASE'
-  testCompile group: 'junit', name: 'junit', version:'4.12'
+  compile group: 'org.springframework', name: 'spring-context', version:'5.2.8.RELEASE'
+  testCompile group: 'io.cucumber', name: 'cucumber-spring', version:'6.5.0'
+  testCompile group: 'io.cucumber', name: 'cucumber-junit', version:'6.5.0'
+  testCompile group: 'org.springframework', name: 'spring-test', version:'5.2.8.RELEASE'
+  testCompile group: 'junit', name: 'junit', version:'4.13'
 }
 
 test {

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,16 @@
     <packaging>jar</packaging>
     <name>Shouty</name>
 
+    <repositories>
+      <repository>
+          <id>sonatype-snapshots</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+          <snapshots>
+              <enabled>true</enabled>
+          </snapshots>
+      </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -17,35 +27,37 @@
 
         <dependency>
             <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>5.0.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-spring</artifactId>
-            <version>3.0.0</version>
+            <version>5.0.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit</artifactId>
-            <version>3.0.0</version>
+            <version>5.0.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <!--
         This (overriding) dependency can be removed post cucumber-jvm 3.0.0
         It overrides the version specified by cucumber-jvm - 1.1.2 adds diffing.
-        -->
+
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>datatable</artifactId>
             <version>1.1.2</version>
-            <scope>test</scope>
-        </dependency>
 
-        <dependency>
-            <groupId>io.cucumber</groupId>
-            <artifactId>pro-plugin</artifactId>
-            <version>2.1.1</version>
             <scope>test</scope>
         </dependency>
+        -->
 
         <dependency>
             <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,16 +8,6 @@
     <packaging>jar</packaging>
     <name>Shouty</name>
 
-    <repositories>
-      <repository>
-          <id>sonatype-snapshots</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-          <snapshots>
-              <enabled>true</enabled>
-          </snapshots>
-      </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -28,21 +18,21 @@
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>
-            <version>5.4.0</version>
+            <version>5.4.2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-spring</artifactId>
-            <version>5.4.0</version>
+            <version>5.4.2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit</artifactId>
-            <version>5.4.0</version>
+            <version>5.4.2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,54 +22,41 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>4.3.10.RELEASE</version>
+            <version>5.2.3.RELEASE</version>
         </dependency>
 
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>
-            <version>5.0.0-SNAPSHOT</version>
+            <version>5.4.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-spring</artifactId>
-            <version>5.0.0-SNAPSHOT</version>
+            <version>5.4.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit</artifactId>
-            <version>5.0.0-SNAPSHOT</version>
+            <version>5.4.0</version>
             <scope>test</scope>
         </dependency>
-
-        <!--
-        This (overriding) dependency can be removed post cucumber-jvm 3.0.0
-        It overrides the version specified by cucumber-jvm - 1.1.2 adds diffing.
-
-        <dependency>
-            <groupId>io.cucumber</groupId>
-            <artifactId>datatable</artifactId>
-            <version>1.1.2</version>
-
-            <scope>test</scope>
-        </dependency>
-        -->
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>4.3.10.RELEASE</version>
+            <version>5.2.3.RELEASE</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,34 +12,34 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>5.2.3.RELEASE</version>
+            <version>5.2.8.RELEASE</version>
         </dependency>
 
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>
-            <version>5.4.2-SNAPSHOT</version>
+            <version>6.5.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-spring</artifactId>
-            <version>5.4.2-SNAPSHOT</version>
+            <version>6.5.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit</artifactId>
-            <version>5.4.2-SNAPSHOT</version>
+            <version>6.5.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>5.2.3.RELEASE</version>
+            <version>5.2.8.RELEASE</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/shouty/RunCukesTest.java
+++ b/src/test/java/shouty/RunCukesTest.java
@@ -6,7 +6,16 @@ import io.cucumber.junit.Cucumber;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(monochrome = true, plugin = {"pretty", "html:target/cucumber", "rerun:target/rerun.txt", "json:target/cucumber.json"}, snippets = SnippetType.CAMELCASE)
+@CucumberOptions(
+        monochrome = true,
+        plugin = {
+                "pretty",
+                "html:target/cucumber",
+                "rerun:target/rerun.txt",
+                "json:target/cucumber.json"
+        },
+        snippets = SnippetType.CAMELCASE
+)
 public class RunCukesTest {
   // this is the adapter/bridge code
   // between cucumber jvm and junit

--- a/src/test/java/shouty/RunCukesTest.java
+++ b/src/test/java/shouty/RunCukesTest.java
@@ -1,12 +1,12 @@
 package shouty;
 
-import cucumber.api.CucumberOptions;
-import cucumber.api.SnippetType;
-import cucumber.api.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import io.cucumber.junit.CucumberOptions.SnippetType;
+import io.cucumber.junit.Cucumber;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(monochrome = true, plugin = {"pretty", "html:target/cucumber", "rerun:target/rerun.txt", "json:target/cucumber.json", "io.cucumber.pro.JsonReporter"}, snippets = SnippetType.CAMELCASE)
+@CucumberOptions(monochrome = true, plugin = {"pretty", "html:target/cucumber", "rerun:target/rerun.txt", "json:target/cucumber.json"}, snippets = SnippetType.CAMELCASE)
 public class RunCukesTest {
   // this is the adapter/bridge code
   // between cucumber jvm and junit

--- a/src/test/java/shouty/ShoutSteps.java
+++ b/src/test/java/shouty/ShoutSteps.java
@@ -1,8 +1,8 @@
 package shouty;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/shouty/ShoutSteps.java
+++ b/src/test/java/shouty/ShoutSteps.java
@@ -1,5 +1,8 @@
 package shouty;
 
+import io.cucumber.java.DataTableType;
+import io.cucumber.java.DocStringType;
+import io.cucumber.java.ParameterType;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;

--- a/src/test/java/shouty/ShoutyTypes.java
+++ b/src/test/java/shouty/ShoutyTypes.java
@@ -1,23 +1,4 @@
 package shouty;
 
-import io.cucumber.core.api.TypeRegistry;
-import io.cucumber.cucumberexpressions.CaptureGroupTransformer;
-import io.cucumber.cucumberexpressions.ParameterType;
-import io.cucumber.datatable.DataTableType;
-import io.cucumber.datatable.TableEntryTransformer;
-
-import java.util.Locale;
-
-import static java.lang.Integer.parseInt;
-
-public class ShoutyTypes implements io.cucumber.core.api.TypeRegistryConfigurer {
-    @Override
-    public Locale locale() {
-        return Locale.ENGLISH;
-    }
-
-    @Override
-    public void configureTypeRegistry(TypeRegistry typeRegistry) {
-    }
-
+public class ShoutyTypes {
 }

--- a/src/test/java/shouty/ShoutyTypes.java
+++ b/src/test/java/shouty/ShoutyTypes.java
@@ -1,6 +1,6 @@
 package shouty;
 
-import cucumber.api.TypeRegistry;
+import io.cucumber.core.api.TypeRegistry;
 import io.cucumber.cucumberexpressions.CaptureGroupTransformer;
 import io.cucumber.cucumberexpressions.ParameterType;
 import io.cucumber.datatable.DataTableType;
@@ -10,7 +10,7 @@ import java.util.Locale;
 
 import static java.lang.Integer.parseInt;
 
-public class ShoutyTypes implements cucumber.api.TypeRegistryConfigurer {
+public class ShoutyTypes implements io.cucumber.core.api.TypeRegistryConfigurer {
     @Override
     public Locale locale() {
         return Locale.ENGLISH;


### PR DESCRIPTION
The `TypeRegistryConfigurer` is deprecated in favour of annotation-based definition of parameter types and doc string / data table converters. See https://github.com/cucumber/cucumber-jvm/blob/master/examples/java-calculator/src/test/java/io/cucumber/examples/java/ShoppingSteps.java

I have left the (unused) imports in the file so it's easier for cyber dojo users.